### PR TITLE
DEVBI-517: updated dockerfile to align python version (3.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3.8.12
+#the latest released Airflow image with default Python version (3.8 currently):
+FROM python:3.8
 
 RUN python -m venv /opt/venv
 
 # Install airflow
-ENV PYTHON_VERSION 3.8.12
-ENV AIRFLOW_VERSION=2.5.1
+ENV PYTHON_VERSION 3.8
+ENV AIRFLOW_VERSION=2.2.4
+RUN pip install --upgrade pip
 ENV CONSTRAINT_URL "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
 RUN pip install "apache-airflow[async,postgres,google,cncf.kubernetes]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
@@ -18,7 +20,7 @@ RUN pip install PyGithub==1.55
 
 RUN mkdir /action
 COPY dag_validation.py /action/dag_validation.py
-COPY alert.py action/alert.py
+COPY alert.py /action/alert.py
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Want to test airflow DAGs on folder tests/dags with a given plugins in tests/plu
 - And boolean flag for whether to load example dags or not
 
 Workflows `.github/workflows/main.yml`
+
 ```yml
 - name: 'Validate DAGs'
-  uses: jayamanikharyono/airflow-dag-action@v2.3
+  uses: lewisosborne/airflow-dag-action@v1.0.1
   with:
     requirementsFile: tests/requirements.txt
     dagPaths: tests/dags
@@ -28,16 +29,18 @@ Workflows `.github/workflows/main.yml`
     loadExample: False
     accessToken: ${{ secrets.GITHUB_TOKEN }}
 ```
+
 **Result**
 ![PR comment](images/comments_pr.png)
 
 ### Todo
+
 - Output Validation Result to PR comments ✅
 - Upgrading to Airflow 2.0+ ✅
 - Add Airflow Plugins Validation ✅
 - Add Airflow Connections Validation ✅
-- Output Detailed Validation Result for Plugins and Connections 
-
+- Output Detailed Validation Result for Plugins and Connections
 
 #### Contributions
+
 Contributions are very welcome. You can follow this standard [contributions guidelines](https://github.com/firstcontributions/first-contributions) to contribute code.


### PR DESCRIPTION
- `docker build .` runs ✅ & installs dependencies 💪
- Use of python 3.8 to align with the version used in our production airflow & its package requirements
- Why are we doing this? Well, currently the airflow-dag-action fails CI validation on a PR that introduces `airflow-provider-fivetran-async==2.0.0` ... which we must use, because a related package is being deprecated. See [this PR](https://github.com/onrunning/bi-airflow/pull/108)

- TODO: update airflow version to align with Composers (i.e. 2.2.4 -> 2.5.1)?